### PR TITLE
Fix heatmap layout by changing td display property

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     }
 
     #chart table tr td {
-      display: block;
+      display: table-cell;
       height: 30px;
       width: 30px;
     }


### PR DESCRIPTION
- I changed CSS for `#chart table tr td` from `display: block;` to `display: table-cell;`.
- This ensures that the heatmap cells render in a grid/table layout instead of a single column.